### PR TITLE
Change the open file limit for stunnel

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -32,6 +32,8 @@ suites:
               - stunnel
         stunnel.sls:
           stunnel:
+            lookup:
+              open_file_limit: 4096
             config:
               pid: /var/run/stunnel.pid
               services:

--- a/stunnel/map.jinja
+++ b/stunnel/map.jinja
@@ -16,12 +16,14 @@
     }
 }, merge=True)%}
 
-{% do stunnel.lookup.update(salt['grains.filter_by']({
+{% set lookup = salt['pillar.get']('stunnel:lookup', salt['grains.filter_by']({
     'upstart': {
         'init_file': '/etc/init/stunnel.conf'
     },
     'systemd': {
         'init_file': '/etc/systemd/system/stunnel.service'
     }
-}, grain='init'))
+}, grain='init'), merge=True)
 %}
+
+ {% do stunnel.lookup.update(lookup) %}

--- a/stunnel/map.jinja
+++ b/stunnel/map.jinja
@@ -7,7 +7,8 @@
             'default_group': 'stunnel4',
             'home': '/var/lib/stunnel4',
             'conf_dir': '/etc/stunnel',
-            'log_dir': '/var/log/stunnel'
+            'log_dir': '/var/log/stunnel',
+            'open_file_limit': '65536'
         }
     }, default='Debian'),
     'config': {

--- a/stunnel/templates/systemd.jinja
+++ b/stunnel/templates/systemd.jinja
@@ -10,6 +10,7 @@ PIDFile={{stunnel.config.pid}}
 ExecStart=/usr/bin/stunnel4 {{ stunnel.lookup.conf_dir }}/stunnel.conf
 Restart=always
 RestartSec=5s
+LimitNOFILE={{stunnel.lookup.open_file_limit}}
 
 [Install]
 WantedBy=multi-user.target

--- a/stunnel/templates/upstart.jinja
+++ b/stunnel/templates/upstart.jinja
@@ -12,7 +12,7 @@ console log
 
 expect fork
 exec /usr/bin/stunnel4 {{ stunnel.lookup.conf_dir }}/stunnel.conf
-limit nofile 65536 65536
+limit nofile {{stunnel.lookup.open_file_limit}} {{stunnel.lookup.open_file_limit}}
 
 # The main stunnel process is actually the last launched. Killing the pid
 # tracked by upstart leaves this process running. This is dirty but

--- a/stunnel/templates/upstart.jinja
+++ b/stunnel/templates/upstart.jinja
@@ -12,6 +12,7 @@ console log
 
 expect fork
 exec /usr/bin/stunnel4 {{ stunnel.lookup.conf_dir }}/stunnel.conf
+limit nofile 65536 65536
 
 # The main stunnel process is actually the last launched. Killing the pid
 # tracked by upstart leaves this process running. This is dirty but

--- a/test/integration/default/upstart.rb
+++ b/test/integration/default/upstart.rb
@@ -1,0 +1,13 @@
+if os[:family] == 'debian' && os[:release] == '14.04'
+  describe file('/etc/init/stunnel.conf') do
+    it { should be_file }
+    its(:content) { should match /limit nofile 4096 4096/ }
+  end
+end
+
+if os[:family] == 'debian' && os[:release] == '16.04'
+  describe file('/etc/systemd/system/stunnel.service') do
+    it { should be_file }
+    its(:content) { should match /LimitNOFILE=4096/ }
+  end
+end


### PR DESCRIPTION
- Stunnel bases the max number of connections on the open file limit.

- Ubuntu 14.04 sets this limit to 1024 for (upstart) spawned processes,
  regardless of `ulimit -n`

- Set the open file limit for the upstart-ed stunnel to 65536, which is what
  `ulimit -n` returns on `redis-02.heap`